### PR TITLE
Add `azimuth` to the calorimetric RETROLux tests

### DIFF
--- a/tests/valid/calorimetricData/RETROLuxOwithHeatControlGlazingCalorimetric.json
+++ b/tests/valid/calorimetricData/RETROLuxOwithHeatControlGlazingCalorimetric.json
@@ -4,7 +4,8 @@
       {
         "side": "exterior",
         "direction": {
-          "polar": 0
+          "polar": 0,
+          "azimuth": 0
         }
       }
     ]

--- a/tests/valid/calorimetricData/RETROLuxOwithSolarControlGlazingCalorimetric.json
+++ b/tests/valid/calorimetricData/RETROLuxOwithSolarControlGlazingCalorimetric.json
@@ -4,7 +4,8 @@
       {
         "side": "exterior",
         "direction": {
-          "polar": 0
+          "polar": 0,
+          "azimuth": 0
         }
       }
     ]


### PR DESCRIPTION
This helps to explain the direction of incidence used in
calorimetricData.json.