### PR TITLE
Add release actions

### DIFF
--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -1,0 +1,66 @@
+# Almost literally taken from
+# https://github.com/thomaseizinger/github-action-gitflow-release-workflow/blob/dev/.github/workflows/draft-new-release.yml
+
+name: "Draft new release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'The version you want to release following semantic versioning (for example, `v1.4.3`, see https://semver.org).'
+        required: true
+
+jobs:
+  draft-new-release:
+    name: "Draft new release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Create release branch
+        run: git checkout -b release/${{ github.event.inputs.version }}
+
+      - name: Update changelog
+        uses: thomaseizinger/keep-a-changelog-new-release@1.2.1
+        with:
+          version: ${{ github.event.inputs.version }}
+
+      # In order to make a commit, we need to initialize a user.
+      # You may choose to write something less generic here if you want, it doesn't matter functionality wise.
+      - name: Initialize mandatory git config
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email noreply@github.com
+      # This step will differ depending on your project setup
+      # Fortunately, yarn has a built-in command for doing this!
+      - name: Bump version in frontend/package.json
+        working-directory: ./frontend
+        run: yarn version --new-version ${{ github.event.inputs.version }} --no-git-tag-version
+
+      - name: Commit changelog and manifest files
+        id: make-commit
+        run: |
+          git add CHANGELOG.md frontend/package.json
+          git commit --message "Prepare release ${{ github.event.inputs.version }}"
+          echo "::set-output name=commit::$(git rev-parse HEAD)"
+      - name: Push new branch
+        run: git push origin release/${{ github.event.inputs.version }}
+
+      - name: Create pull request
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: release/${{ github.event.inputs.version }}
+          base: main
+          title: Release version ${{ github.event.inputs.version }}
+          reviewers: ${{ github.actor }} # By default, we request a review from the person who triggered the workflow.
+          # Write a nice message to the user.
+          # We are claiming things here based on the `publish-new-release.yml` workflow.
+          # You should obviously adopt it to say the truth depending on your release workflow :)
+          body: |
+            Hi @${{ github.actor }}!
+
+            This pull request was created in response to a manual trigger of the release workflow here: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}.
+            I've updated the changelog and bumped the versions in the manifest files in this commit: ${{ steps.make-commit.outputs.commit }}.
+            Merging this pull request will create a GitHub release and upload any assets that are created as part of the release build.

--- a/.github/workflows/publish-new-release.yml
+++ b/.github/workflows/publish-new-release.yml
@@ -1,0 +1,54 @@
+# Almost literally taken from
+# https://github.com/thomaseizinger/github-action-gitflow-release-workflow/blob/dev/.github/workflows/publish-new-release.yml
+
+name: "Publish new release"
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  release:
+    name: Publish new release
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true # only merged pull requests must trigger this job
+    steps:
+      - name: Extract version from branch name (for release branches)
+        if: startsWith(github.event.pull_request.head.ref, 'release/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#release/}
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Extract version from branch name (for hotfix branches)
+        if: startsWith(github.event.pull_request.head.ref, 'hotfix/')
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          VERSION=${BRANCH_NAME#hotfix/}
+          echo "RELEASE_VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Create Release
+        uses: thomaseizinger/create-release@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target_commitish: ${{ github.event.pull_request.merge_commit_sha }}
+          tag_name: ${{ env.RELEASE_VERSION }}
+          name: ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: false
+
+      - name: Merge main into develop branch
+        uses: thomaseizinger/create-pull-request@1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          head: main
+          base: develop
+          title: Merge main into develop branch
+          body: |
+            This pull request merges the main branch back into develop.
+            This happens to ensure that the updates that happend on the release branch, in particular, CHANGELOG and manifest updates, are also present on the develop branch.
+      # if needed, you can checkout the latest main here, build artifacts and publish / deploy them somewhere
+      # the create-release action has an output `upload_url` output that you can use to upload assets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to
 - Add the key `roughness` [#205](https://github.com/building-envelope-data/api/pull/205)
 - Add the position of coatings to components [#223](https://github.com/building-envelope-data/api/pull/223)
 - Add `currentVoltage` characteristics for modules [#224](https://github.com/building-envelope-data/api/pull/224)
--
+- Add release actions [#281](https://github.com/building-envelope-data/api/pull/281)
 -
 -
 -


### PR DESCRIPTION
Two [GitHub Actions](https://github.com/building-envelope-data/api/actions) to create releases.

1. [Draft a new release](https://github.com/building-envelope-data/api/actions/workflows/draft-new-release.yml) with a new version according to [Semantic Versioning](https://semver.org) by running the GitHub action which, in particular, creates a new branch named `release/v*.*.*`, where `*.*.*` is the version, and a corresponding pull request.
1. Fetch the release branch by running `git fetch` and check it out by running `git checkout release/v*.*.*`, where `*.*.*` is the version.
1. Prepare the release if necessary, add, commit, and push the changes.
1. [Publish the new release](https://github.com/building-envelope-data/api/actions/workflows/publish-new-release.yml) by merging the release branch into `main` whereby a new pull request from `main` into `develop` is created that you need to merge to finish off.