### PR TITLE
Remove the `nodes` shortcut in repo `api`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -193,6 +193,7 @@ and this project adheres to
 - Add spectrum `ultraviolet` for integral values and improve the optical examples [#247](https://github.com/building-envelope-data/api/pull/247)
 - Change propositions for lists and make parameter `where` optional [#260](https://github.com/building-envelope-data/api/pull/260)
 - Move `color` to the `results` of an optical data set [#326](https://github.com/building-envelope-data/api/pull/326)
+- Remove the shortcut `nodes` to reduce the implementation effort [#318](https://github.com/building-envelope-data/api/pull/318)
 
 ### Removed
 

--- a/apis/database.graphql
+++ b/apis/database.graphql
@@ -923,15 +923,6 @@ type DataConnection {
   edges: [DataEdge!]!
 
   """
-  Data nodes to avoid the layer of indirection through edges in case edge meta
-  data is not needed. It is equal to the list comprehension
-  ```
-  [edge.node for edge in edges]
-  ```
-  """
-  nodes: [Data!]!
-
-  """
   Total number of data edges (and nodes) of which a slice is `edges` (and
   `nodes`). Note that the number of edges (and nodes) of the present slice is
   `pageInfo.count`.
@@ -982,7 +973,6 @@ See `DataConnection`.
 """
 type OpticalDataConnection {
   edges: [OpticalDataEdge!]!
-  nodes: [OpticalData!]!
   pageInfo: PageInfo!
   timestamp: DateTime!
 }
@@ -1000,7 +990,6 @@ See `DataConnection`.
 """
 type HygrothermalDataConnection {
   edges: [HygrothermalDataEdge!]!
-  nodes: [HygrothermalData!]!
   pageInfo: PageInfo!
   timestamp: DateTime!
 }
@@ -1018,7 +1007,6 @@ See `DataConnection`.
 """
 type PhotovoltaicDataConnection {
   edges: [PhotovoltaicDataEdge!]!
-  nodes: [PhotovoltaicData!]!
   pageInfo: PageInfo!
   timestamp: DateTime!
 }
@@ -1036,7 +1024,6 @@ See `DataConnection`.
 """
 type CalorimetricDataConnection {
   edges: [CalorimetricDataEdge!]!
-  nodes: [CalorimetricData!]!
   pageInfo: PageInfo!
   timestamp: DateTime!
 }
@@ -1046,7 +1033,6 @@ See `DataConnection`.
 """
 type GeometricDataConnection {
   edges: [GeometricDataEdge!]!
-  nodes: [GeometricData!]!
   pageInfo: PageInfo!
   timestamp: DateTime!
 }

--- a/queries/database/allData.graphql
+++ b/queries/database/allData.graphql
@@ -2,16 +2,20 @@ query {
   byComponentId: allData(
     where: { componentId: { equalTo: "810e84b4-9ebf-416c-88ea-aade848f1fdf" } }
   ) {
-    nodes {
-      uuid
+    edges {
+      node {
+        uuid
+      }
     }
   }
 
   byNegation: allData(
     where: { not: { gValues: { some: { greaterThanOrEqualTo: 0.5 } } } }
   ) {
-    nodes {
-      uuid
+    edges {
+      node {
+        uuid
+      }
     }
   }
 
@@ -23,8 +27,10 @@ query {
       ]
     }
   ) {
-    nodes {
-      uuid
+    edges {
+      node {
+        uuid
+      }
     }
   }
 
@@ -41,8 +47,10 @@ query {
       ]
     }
   ) {
-    nodes {
-      uuid
+    edges {
+      node {
+        uuid
+      }
     }
   }
 

--- a/queries/database/tutorial.graphql
+++ b/queries/database/tutorial.graphql
@@ -2,11 +2,13 @@ query {
   resourcesByComponent: allOpticalData(
     where: { componentId: { equalTo: "3ffc64af-d1f3-4a2e-a646-b007b7137245" } }
   ) {
-    nodes {
-      resourceTree {
-        root {
-          value {
-            locator
+    edges {
+      node {
+        resourceTree {
+          root {
+            value {
+              locator
+            }
           }
         }
       }
@@ -14,12 +16,14 @@ query {
   }
 
   allData: allData {
-    nodes {
-      name
-      resourceTree {
-        root {
-          value {
-            locator
+    edges {
+      node {
+        name
+        resourceTree {
+          root {
+            value {
+              locator
+            }
           }
         }
       }
@@ -49,12 +53,14 @@ query {
       ]
     }
   ) {
-    nodes {
-      componentId
-      resourceTree {
-        root {
-          value {
-            locator
+    edges {
+      node {
+        componentId
+        resourceTree {
+          root {
+            value {
+              locator
+            }
           }
         }
       }
@@ -62,21 +68,25 @@ query {
   }
 
   allOpticalDataSets: allOpticalData {
-    nodes {
-      name
+    edges {
+      node {
+        name
+      }
     }
   }
 
   integralOpticalValuesOfComponent: allOpticalData(
     where: { componentId: { equalTo: "3ffc64af-d1f3-4a2e-a646-b007b7137245" } }
   ) {
-    nodes {
-      nearnormalHemisphericalVisibleReflectances
-      nearnormalHemisphericalVisibleTransmittances
-      resourceTree {
-        root {
-          value {
-            locator
+    edges {
+      node {
+        nearnormalHemisphericalVisibleReflectances
+        nearnormalHemisphericalVisibleTransmittances
+        resourceTree {
+          root {
+            value {
+              locator
+            }
           }
         }
       }

--- a/queries/metabase/tutorial.graphql
+++ b/queries/metabase/tutorial.graphql
@@ -1,8 +1,10 @@
 query {
   institutionByString: institutions(where: { name: { contains: "Suno" } }) {
-    nodes {
-      name
-      uuid
+    edges {
+      node {
+        name
+        uuid
+      }
     }
   }
 
@@ -20,20 +22,24 @@ query {
   }
 
   resourcesByComponent: databases {
-    nodes {
-      uuid
-      name
-      locator
-      allOpticalData(
-        where: {
-          componentId: { equalTo: "9386f355-2069-4490-bdd1-e1acdb233e12" }
-        }
-      ) {
-        nodes {
-          resourceTree {
-            root {
-              value {
-                locator
+    edges {
+      node {
+        uuid
+        name
+        locator
+        allOpticalData(
+          where: {
+            componentId: { equalTo: "9386f355-2069-4490-bdd1-e1acdb233e12" }
+          }
+        ) {
+          edges {
+            node {
+              resourceTree {
+                root {
+                  value {
+                    locator
+                  }
+                }
               }
             }
           }
@@ -43,14 +49,18 @@ query {
   }
 
   allData: databases {
-    nodes {
-      allData {
-        nodes {
-          name
-          resourceTree {
-            root {
-              value {
-                locator
+    edges {
+      node {
+        allData {
+          edges {
+            node {
+              name
+              resourceTree {
+                root {
+                  value {
+                    locator
+                  }
+                }
               }
             }
           }
@@ -60,22 +70,26 @@ query {
   }
 
   dataFormat: databases {
-    nodes {
-      name
-      allOpticalData(
-        where: {
-          resources: {
-            some: {
-              dataFormatId: { equalTo: "e021cf20-e887-4dce-ad27-35da70cec472" }
+    edges {
+      node {
+        name
+        allOpticalData(
+          where: {
+            resources: {
+              some: {
+                dataFormatId: { equalTo: "e021cf20-e887-4dce-ad27-35da70cec472" }
+              }
             }
           }
-        }
-      ) {
-        nodes {
-          resourceTree {
-            root {
-              value {
-                locator
+        ) {
+          edges {
+            node {
+              resourceTree {
+                root {
+                  value {
+                    locator
+                  }
+                }
               }
             }
           }
@@ -85,39 +99,43 @@ query {
   }
 
   dataSetsByOpticalPropertiesAndDataFormat: databases {
-    nodes {
-      name
-      allOpticalData(
-        where: {
-          and: [
-            {
-              nearnormalHemisphericalVisibleTransmittances: {
-                some: { greaterThanOrEqualTo: 0.605 }
+    edges {
+      node {
+        name
+        allOpticalData(
+          where: {
+            and: [
+              {
+                nearnormalHemisphericalVisibleTransmittances: {
+                  some: { greaterThanOrEqualTo: 0.605 }
+                }
               }
-            }
-            {
-              nearnormalHemisphericalSolarTransmittances: {
-                some: { lessThanOrEqualTo: 0.228 }
+              {
+                nearnormalHemisphericalSolarTransmittances: {
+                  some: { lessThanOrEqualTo: 0.228 }
+                }
               }
-            }
-            {
-              resources: {
-                some: {
-                  dataFormatId: {
-                    equalTo: "9ca9e8f5-94bf-4fdd-81e3-31a58d7ca708"
+              {
+                resources: {
+                  some: {
+                    dataFormatId: {
+                      equalTo: "9ca9e8f5-94bf-4fdd-81e3-31a58d7ca708"
+                    }
                   }
                 }
               }
-            }
-          ]
-        }
-      ) {
-        nodes {
-          componentId
-          resourceTree {
-            root {
-              value {
-                locator
+            ]
+          }
+        ) {
+          edges {
+            node {
+              componentId
+              resourceTree {
+                root {
+                  value {
+                    locator
+                  }
+                }
               }
             }
           }
@@ -127,35 +145,43 @@ query {
   }
 
   allOpticalDataSets: databases {
-    nodes {
-      allOpticalData {
-        nodes {
-          name
+    edges {
+      node {
+        allOpticalData {
+          edges {
+            node {
+              name
+            }
+          }
         }
       }
     }
   }
 
   integralOpticalValuesOfComponent: databases {
-    nodes {
-      uuid
-      name
-      locator
-      allOpticalData(
-        where: {
-          componentId: { equalTo: "ccd459b5-ddd0-4fbf-8206-7c39d1b7a34e" }
-        }
-      ) {
-        nodes {
-          nearnormalHemisphericalSolarReflectances
-          nearnormalHemisphericalSolarTransmittances
-          nearnormalHemisphericalVisibleReflectances
-          nearnormalHemisphericalVisibleTransmittances
-          infraredEmittances
-          resourceTree {
-            root {
-              value {
-                locator
+    edges {
+      node {
+        uuid
+        name
+        locator
+        allOpticalData(
+          where: {
+            componentId: { equalTo: "ccd459b5-ddd0-4fbf-8206-7c39d1b7a34e" }
+          }
+        ) {
+          edges {
+            node {
+              nearnormalHemisphericalSolarReflectances
+              nearnormalHemisphericalSolarTransmittances
+              nearnormalHemisphericalVisibleReflectances
+              nearnormalHemisphericalVisibleTransmittances
+              infraredEmittances
+              resourceTree {
+                root {
+                  value {
+                    locator
+                  }
+                }
               }
             }
           }

--- a/queries/metabase/tutorial.graphql
+++ b/queries/metabase/tutorial.graphql
@@ -77,7 +77,9 @@ query {
           where: {
             resources: {
               some: {
-                dataFormatId: { equalTo: "e021cf20-e887-4dce-ad27-35da70cec472" }
+                dataFormatId: {
+                  equalTo: "e021cf20-e887-4dce-ad27-35da70cec472"
+                }
               }
             }
           }


### PR DESCRIPTION
[#317](https://github.com/building-envelope-data/api/issues/317) has implications on several repositories. In this repo `api`, [database.graphql](https://github.com/building-envelope-data/api/tree/develop/apis/database.graphql) and the [queries](https://github.com/building-envelope-data/api/tree/develop/queries) have been updated. metabase.graphql will be updated based on the repository [metabase](https://github.com/building-envelope-data/metabase).

This change shall make it easier for the product data servers to implement the API specification.